### PR TITLE
Alignment to match latest Material specs in Compose

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -15,6 +13,7 @@
             <option value="$PROJECT_DIR$/listitem" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.20" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.9.0" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 junit = { module = "junit:junit", version = "4.13.2" }
-material = { module = "com.google.android.material:material", version = "1.10.0" }
+material = { module = "com.google.android.material:material", version = "1.11.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/listitem/src/main/java/net/nicbell/materiallists/ListItem.kt
+++ b/listitem/src/main/java/net/nicbell/materiallists/ListItem.kt
@@ -49,7 +49,7 @@ open class ListItem @JvmOverloads constructor(
                 supportText.text = getString(R.styleable.ListItem_supportText).orEmpty()
 
                 getInt(R.styleable.ListItem_sizeType, ListItemSizeType.OneLine.ordinal).run {
-                    setSizeType(ListItemSizeType.values()[this])
+                    setSizeType(ListItemSizeType.entries[this])
                 }
 
                 getBoolean(R.styleable.ListItem_showDivider, true).run {

--- a/listitem/src/main/res/layout/material_lists_list_item.xml
+++ b/listitem/src/main/res/layout/material_lists_list_item.xml
@@ -102,7 +102,7 @@
         android:id="@+id/divider"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:dividerColor="?colorSurfaceVariant"
+        app:dividerColor="?colorOutlineVariant"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@id/guide_end"
         app:layout_constraintStart_toStartOf="@id/guide_start" />

--- a/listitem/src/main/res/layout/material_lists_list_item.xml
+++ b/listitem/src/main/res/layout/material_lists_list_item.xml
@@ -27,7 +27,7 @@
         android:layout_height="0dp"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintGuide_end="@dimen/list_item_space_x6"
+        app:layout_constraintGuide_end="@dimen/list_item_space_x4"
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.Guideline
@@ -103,7 +103,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:dividerColor="?colorOutlineVariant"
+        app:dividerInsetEnd="@dimen/list_item_space_x4"
+        app:dividerInsetStart="@dimen/list_item_space_x4"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/guide_end"
-        app:layout_constraintStart_toStartOf="@id/guide_start" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 </merge>

--- a/listitem/src/main/res/values/styles.xml
+++ b/listitem/src/main/res/values/styles.xml
@@ -116,7 +116,7 @@
         <item name="layout_constraintTop_toTopOf">parent</item>
         <item name="layout_constraintBottom_toBottomOf">parent</item>
         <item name="android:layout_marginStart">@dimen/list_item_space_x1</item>
-        <item name="android:layout_marginEnd">@dimen/list_item_space_x3</item>
+        <item name="android:layout_marginEnd">@dimen/list_item_space_x1</item>
     </style>
 
     <style name="MaterialLists.TrailingRadioButton">
@@ -125,8 +125,10 @@
         <item name="layout_constraintEnd_toEndOf">parent</item>
         <item name="layout_constraintTop_toTopOf">parent</item>
         <item name="layout_constraintBottom_toBottomOf">parent</item>
-        <item name="android:layout_marginStart">@dimen/list_item_space_x3</item>
-        <item name="android:layout_marginEnd">@dimen/list_item_space_x1</item>
+        <!-- Hack because of: https://github.com/material-components/material-components-android/issues/3301 -->
+        <item name="android:rotation">180</item>
+        <item name="android:layout_marginStart">@dimen/list_item_space_x1</item>
+        <item name="android:layout_marginEnd">@dimen/list_item_space_x3</item>
     </style>
 
     <style name="MaterialLists.TrailingSwitch">
@@ -135,8 +137,8 @@
         <item name="layout_constraintEnd_toEndOf">parent</item>
         <item name="layout_constraintTop_toTopOf">parent</item>
         <item name="layout_constraintBottom_toBottomOf">parent</item>
-        <item name="android:layout_marginStart">@dimen/list_item_space_x1</item>
-        <item name="android:layout_marginEnd">@dimen/list_item_space_x5</item>
+        <item name="android:layout_marginStart">@dimen/list_item_space_x2</item>
+        <item name="android:layout_marginEnd">@dimen/list_item_space_x3</item>
     </style>
 
     <style name="MaterialLists.TrailingSupportingText">

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_List Item 3 lines[Mode: NIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_List Item 3 lines[Mode: NIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02ee8268631f52be64956b3e3ce49eddee03d74da070b92c99cbde239f370db2
-size 82174
+oid sha256:bffa1a7ba79e11e90314eba327d3ced0ee12e90a157c90319a580c48f4d2bb40
+size 82739

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_List Item 3 lines[Mode: NOTNIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_List Item 3 lines[Mode: NOTNIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:299157bbd5d8b73ba4b0030aefdc9c2e40fb1cb92a3bf5483448d16fb6e3b550
-size 78703
+oid sha256:7c75b247b6af3820bc2a37732ab20f79a23e8f68fa7911d1e53e6cf2801a13c3
+size 81571

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 1 line[Mode: NIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 1 line[Mode: NIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0fad0af7e2f6a7aa034d8ee80a251339cea44eaa11cff820b96eb76916cb2b8
-size 37224
+oid sha256:e81826700fc6213374ce644ba4bd828766d0ea818978db36c82198cedb5a97db
+size 37986

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 1 line[Mode: NOTNIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 1 line[Mode: NOTNIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d28e6d8bb8da05cb38cc6171b5cdded715ca560bc4a3e14810df4f28db083f8c
-size 37743
+oid sha256:b4efa6449d68ab637b3ebc14fddfe3ef7c09bcd887b43d1c3346f7cf449cdfac
+size 37748

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 2 lines[Mode: NIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 2 lines[Mode: NIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c779cbc79e8b3237213313e1dfc81a361680bf444cfc53e2030c5ce8c36e3ffc
-size 45054
+oid sha256:e604e6737978f84b7cb00cb71351308d7afd4e96b7dd80fdbc07434238f4f134
+size 45304

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 2 lines[Mode: NOTNIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem 2 lines[Mode: NOTNIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:592a5da51f87e65eb75fee6266b6f69d1ce57e852b2aaf290f51c5af0b6d85b7
-size 44460
+oid sha256:45bfafdf59de5f730fc04ad23190b37130f4a426cc0a02956160ad1bf5360e6c
+size 44985

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NIGHT]_1.png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NIGHT]_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f16c9a6c7fcf0bdfb70d071cfdcdb0481ee1ec14a44b60cf7c86b5c71f1996d
-size 6068
+oid sha256:0742b69d63da716c95f6234e867171badbd982583f81d3d02d37a0ecfa6f1d0e
+size 6103

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NIGHT]_2.png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NIGHT]_2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f9ea1c621ae509da6412d03788dc306e40318164d7914958ed65c3fead7acdb2
-size 11590
+oid sha256:5fa3082aece747380fd80f0ff4b0bd7590582d3633a93a92f8a414887fa76a05
+size 11659

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NIGHT]_3.png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NIGHT]_3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd05ebf42c0d867bac64073a1a7299f524c352078450461ab2e741a7ffdc5326
-size 13644
+oid sha256:be5fdc2d1f4cbd8d107ca6173f696d1fd6701748b45349ec14ddbb3e3f2a7308
+size 13615

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NOTNIGHT]_1.png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NOTNIGHT]_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92f18ae62a2d01dc9e69c3fc5f6989bc8b904607e6f4273bc338d17df84842f7
-size 6124
+oid sha256:1fb7c57a432fae3980923341bacef7ff9a6adb32ec0045cef7c82d04593dda78
+size 6133

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NOTNIGHT]_2.png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NOTNIGHT]_2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:715c791b47adb1fa2b18171bdeaa21b26ee545b04ac5995e35126e041fff972e
-size 11287
+oid sha256:b08e4f5f8edff6c314079a8b76e8d4fd01db0e1cef12a4bd160d6b29f5c1bbcc
+size 11554

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NOTNIGHT]_3.png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem change size[Mode: NOTNIGHT]_3.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6c7ef75a364e09003992cf8015d3bdda1eef063c6abbae6952f0d858ac73b54
-size 13241
+oid sha256:16c29454b491cf37d48c4eaccb28c5a7114eec94db66102c50e817485b9243d3
+size 13575

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem programmatic[Mode: NIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem programmatic[Mode: NIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3bd38f321b5fd9cae972254b12da8889dad6d21a5978338ef38587cdc900e275
-size 6110
+oid sha256:6290ddeaedbd4b98a2b0ceddf1b875194089854f45f579b78d1e5ed7dcfa927e
+size 6143

--- a/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem programmatic[Mode: NOTNIGHT].png
+++ b/listitem/src/test/snapshots/images/net.nicbell.materiallists_ListItemTest_ListItem programmatic[Mode: NOTNIGHT].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff9080670a4b89cb31875dd95235c37c9a163ec3d2516c99ac097c2ea59ba741
-size 6171
+oid sha256:de37bcaaa11ee02006eeada1e634c730bb88f05e056e9d6f021f6a71075320df
+size 6178


### PR DESCRIPTION
## Summary

- Upgrade to Material 1.11
- Use outline variant color for dividers
- Make alignment match latest Material spec in compose which is `16dp` rather than `24dp` at the end

https://android-review.googlesource.com/c/platform/frameworks/support/+/2889707/4/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ListItem.kt