### PR TITLE
Rename `showDivider` attribute to `dividerVisible` to prevent clashes with Google FlexBoxLayout lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following attributes can be changed for a `ListItem`.
 | Headline text                | `app:head`          |
 | Supporting text              | `app:supportText`   |
 | Size type - 1, 2 or 3+ lines | `app:sizeType`      |
-| Show divider (default true)  | `app:showDivider`   |
+| Show divider (default true)  | `app:dividerVisible`   |
 | Divider color                | `app:dividerTint`   |
 
 For more info about size types see

--- a/listitem/src/debug/res/layout/test_dyamic_size_change.xml
+++ b/listitem/src/debug/res/layout/test_dyamic_size_change.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:headline="Headline"
-        app:showDivider="false"
+        app:dividerVisible="false"
         app:sizeType="ONE_LINE"
         app:supportText="Hello world I am a multi-line example of list item support text.">
 

--- a/listitem/src/debug/res/layout/test_one_line_layout.xml
+++ b/listitem/src/debug/res/layout/test_one_line_layout.xml
@@ -203,7 +203,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:headline="Headline"
-        app:showDivider="false">
+        app:dividerVisible="false">
 
         <androidx.appcompat.widget.AppCompatImageView
             style="@style/MaterialLists.LeadingVideoThumbnail"

--- a/listitem/src/debug/res/layout/test_three_line_layout.xml
+++ b/listitem/src/debug/res/layout/test_three_line_layout.xml
@@ -19,7 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:headline="Headline"
-        app:showDivider="false"
+        app:dividerVisible="false"
         app:sizeType="THREE_PLUS_LINES"
         app:supportText="Hello world I am a multi-line example of list item support text.">
 

--- a/listitem/src/debug/res/layout/test_two_line_layout.xml
+++ b/listitem/src/debug/res/layout/test_two_line_layout.xml
@@ -165,7 +165,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:headline="Headline"
-        app:showDivider="false"
+        app:dividerVisible="false"
         app:sizeType="TWO_LINES"
         app:supportText="Support text">
 

--- a/listitem/src/main/java/net/nicbell/materiallists/ListItem.kt
+++ b/listitem/src/main/java/net/nicbell/materiallists/ListItem.kt
@@ -52,7 +52,7 @@ open class ListItem @JvmOverloads constructor(
                     setSizeType(ListItemSizeType.entries[this])
                 }
 
-                getBoolean(R.styleable.ListItem_showDivider, true).run {
+                getBoolean(R.styleable.ListItem_dividerVisible, true).run {
                     divider.isVisible = this
                 }
 

--- a/listitem/src/main/res/values/attrs.xml
+++ b/listitem/src/main/res/values/attrs.xml
@@ -10,7 +10,7 @@
             <enum name="THREE_PLUS_LINES" value="2" />
         </attr>
 
-        <attr name="showDivider" format="boolean" />
+        <attr name="dividerVisible" format="boolean" />
         <attr name="dividerTint" format="color" />
     </declare-styleable>
 


### PR DESCRIPTION
## Summary

Possible to clash with attribute in this library.
https://github.com/google/flexbox-layout/blob/main/flexbox/src/main/res/values/attrs.xml#L67